### PR TITLE
Simulator Documentation for macOS

### DIFF
--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -28,8 +28,7 @@ We need ``genromfs`` to build simulators(NON GUI).
       $ make install
    Now Copy the built `genromfs` exec to /opt/local/bin
 
-For GUI Applications we need X11 Libraries,
-   libx11 can also be build using Homebrew.
+For GUI Applications we need X11 Libraries, libx11 can also be build using Homebrew.
 
    .. code-block:: console
 

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -18,7 +18,7 @@ submit a PR to improve this guide!
 Prerequisites For macOS
 -----------------------
 
-   We need ``genromfs`` to build simulators(NON GUI)
+  We need ``genromfs`` to build simulators(NON GUI)
    
    .. code-block:: console
    
@@ -27,15 +27,15 @@ Prerequisites For macOS
       $make 
       $make install
       
-   Now Copy the built `genromfs` exec to /opt/local/bin
+  Now Copy the built `genromfs` exec to /opt/local/bin
 
-   For GUI Applications we need X11 Libraries
+  For GUI Applications we need X11 Libraries
    
    .. code-block:: console
    
       $sudo port install xorg-libX11
       
-   libx11 can be build using Homebrew also
+  libx11 can be build using Homebrew also
 
 Compiling
 ---------

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -15,11 +15,10 @@ submit a PR to improve this guide!
 
 .. todo:: Windows instructions
 
-
 Prerequisites For macOS
 -----------------------
 
-   We need ``genromfs`` to build simulators(NON GUI).
+We need ``genromfs`` to build simulators(NON GUI).
 
    .. code-block:: console
 
@@ -29,7 +28,7 @@ Prerequisites For macOS
       $ make install
    Now Copy the built `genromfs` exec to /opt/local/bin
 
-   For GUI Applications we need X11 Libraries,
+For GUI Applications we need X11 Libraries,
    libx11 can also be build using Homebrew.
 
    .. code-block:: console

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -15,6 +15,7 @@ submit a PR to improve this guide!
 
 .. todo:: Windows instructions
 
+
 Prerequisites For macOS
 -----------------------
 
@@ -28,11 +29,11 @@ Prerequisites For macOS
       $ make install
    Now Copy the built `genromfs` exec to /opt/local/bin
 
-   For GUI Applications we need X11 Libraries
-   libx11 can be build using Homebrew also
+   For GUI Applications we need X11 Libraries,
+   libx11 can also be build using Homebrew.
 
    .. code-block:: console
-      
+
       $ sudo port install xorg-libX11
 
 Compiling

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -13,7 +13,23 @@ having a piece of embedded hardware.
 This guide assumes you're on Linux. It works on Windows and Mac too— if you know how,
 submit a PR to improve this guide!
 
-.. todo:: Add Mac and Windows instructions
+.. todo:: Windows instructions
+
+Prerequisites For macOS
+-----------------------
+
+   We need ``genromfs`` to build simulators(NON GUI)
+   .. code-block:: console
+      $git clone https://github.com/chexum/genromfs.git
+      $cd genromfs
+      $make 
+      $make install
+   Now Copy the built `genromfs` exec to /opt/local/bin
+
+   For GUI Applications we need X11 Libraries
+   .. code-block:: console
+      $sudo port install xorg-libX11
+   libx11 can be build using Homebrew also
 
 Compiling
 ---------

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -18,24 +18,24 @@ submit a PR to improve this guide!
 Prerequisites For macOS
 -----------------------
 
-  We need ``genromfs`` to build simulators(NON GUI)
+We need ``genromfs`` to build simulators(NON GUI)
    
-   .. code-block:: console
+.. code-block:: console
    
       $git clone https://github.com/chexum/genromfs.git
       $cd genromfs
       $make 
       $make install
       
-  Now Copy the built `genromfs` exec to /opt/local/bin
-
-  For GUI Applications we need X11 Libraries
+Now Copy the built `genromfs` exec to /opt/local/bin
+For GUI Applications we need X11 Libraries
+libx11 can be build using Homebrew also
    
-   .. code-block:: console
+.. code-block:: console
    
-      $sudo port install xorg-libX11
+$sudo port install xorg-libX11
       
-  libx11 can be build using Homebrew also
+  
 
 Compiling
 ---------

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -26,7 +26,7 @@ We need ``genromfs`` to build simulators(NON GUI).
       $ cd genromfs
       $ make 
       $ make install
-   Now Copy the built `genromfs` exec to /opt/local/bin
+   Now Copy the built `genromfs` `exec` to /opt/local/bin
 
 For GUI Applications we need X11 Libraries, libx11 can also be build using Homebrew.
 

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -19,16 +19,22 @@ Prerequisites For macOS
 -----------------------
 
    We need ``genromfs`` to build simulators(NON GUI)
+   
    .. code-block:: console
+   
       $git clone https://github.com/chexum/genromfs.git
       $cd genromfs
       $make 
       $make install
+      
    Now Copy the built `genromfs` exec to /opt/local/bin
 
    For GUI Applications we need X11 Libraries
+   
    .. code-block:: console
+   
       $sudo port install xorg-libX11
+      
    libx11 can be build using Homebrew also
 
 Compiling

--- a/Documentation/guides/simulator.rst
+++ b/Documentation/guides/simulator.rst
@@ -18,24 +18,22 @@ submit a PR to improve this guide!
 Prerequisites For macOS
 -----------------------
 
-We need ``genromfs`` to build simulators(NON GUI)
-   
-.. code-block:: console
-   
-      $git clone https://github.com/chexum/genromfs.git
-      $cd genromfs
-      $make 
-      $make install
+   We need ``genromfs`` to build simulators(NON GUI).
+
+   .. code-block:: console
+
+      $ git clone https://github.com/chexum/genromfs.git
+      $ cd genromfs
+      $ make 
+      $ make install
+   Now Copy the built `genromfs` exec to /opt/local/bin
+
+   For GUI Applications we need X11 Libraries
+   libx11 can be build using Homebrew also
+
+   .. code-block:: console
       
-Now Copy the built `genromfs` exec to /opt/local/bin
-For GUI Applications we need X11 Libraries
-libx11 can be build using Homebrew also
-   
-.. code-block:: console
-   
-$sudo port install xorg-libX11
-      
-  
+      $ sudo port install xorg-libX11
 
 Compiling
 ---------


### PR DESCRIPTION
## Summary
macOS requires genromfs and X11 Libraries to run Simulators.
* Added instructions to install genromfs
* Added instructions to install X11 

## Impact
The Simulator will not run without these tools.

## Testing
This Works on ARM MacBooks.

